### PR TITLE
chore: build image with two stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-*
-!package*.json
-!dist
+.git
+node_modules
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,25 @@
+FROM node:16-alpine as builder
+
+RUN npm install -g eslint
+RUN npm install -g @nestjs/cli
+
+WORKDIR /app
+
+COPY package.json .
+COPY package-lock.json .
+RUN npm install
+
+COPY . .
+RUN npm ci --prod
+RUN npx nest build
+
+
 FROM node:16-alpine
 
 WORKDIR /app
 
-COPY package*.json ./
-RUN npm ci --prod
-
-COPY ./dist ./dist
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/node_modules /app/node_modules
 
 USER node
 


### PR DESCRIPTION
Some optimizations to the build system.

Problem: I found that I encountered an error when using `docker build`, the `dist` directory does not exist, so I can\'t build the repository myself.

Reason: The code inside the main branch is expecting the `dist` directory to already exist when building. This is unreasonable and docker build should not make assumptions.

Workaround: I provided a two-stage build Dockerfile so that I could give anyone the ability to complete `docker build . `.